### PR TITLE
Extract DatalessBaseRanker superclass from BaseRanker for use with data modules

### DIFF
--- a/src/ranking_utils/datasets/trecdl.py
+++ b/src/ranking_utils/datasets/trecdl.py
@@ -72,9 +72,9 @@ class TRECDL2019Passage(ParsableDataset):
 
         # read top documents
         self.pools = defaultdict(set)
-        for f_name, num_lines in [('top1000.train.txt', 478016942),
-                                  ('top1000.dev.tsv', 6668967),
-                                  ('msmarco-passagetest2019-top1000.tsv', 189877)]:
+        for f_name, num_lines in [('top1000.dev.tsv', 6668967),
+                                  ('msmarco-passagetest2019-top1000.tsv', 189877),
+                                  ('top1000.train.txt', 478016942)]:
             f = self.directory / f_name
             print(f'reading {f}...')
             with open(f, encoding='utf-8', newline='') as fp:

--- a/src/ranking_utils/lightning/base_ranker.py
+++ b/src/ranking_utils/lightning/base_ranker.py
@@ -42,7 +42,7 @@ class DatalessBaseRanker(LightningModule, abc.ABC):
         elif self.training_mode == 'pairwise':
             self.loss_margin = loss_margin
         else:
-            raise ValueError(f'Unknow training mode: {training_mode}')
+            raise ValueError(f'Unknown training mode: {training_mode}')
 
         self.val_metrics = MetricCollection([
             RetrievalMAP(compute_on_step=False),

--- a/src/ranking_utils/lightning/base_ranker.py
+++ b/src/ranking_utils/lightning/base_ranker.py
@@ -166,7 +166,15 @@ class BaseRanker(DatalessBaseRanker, abc.ABC):
         super().__init__(training_mode=training_mode,
                          loss_margin=loss_margin)
 
+        # FIXME: I think what's supposed to happen here is to fold hparams into the previously
+        # extracted (by save_hyperparameters, in DataLessBaseRanker.__init__) hparams.
+        # This means, though, that values in hparams will override those extracted from
+        # the call stack. Is that what we want?
+        #
+        # FK 2022-01-26
         self.hparams.update(hparams)
+        # For compatibility with existing code. These also show up in hparams but may be
+        # different from self.hparams['batch_size'] etc. See previous comment.
         self.batch_size = batch_size
         self.num_workers = num_workers
         

--- a/src/ranking_utils/lightning/base_ranker.py
+++ b/src/ranking_utils/lightning/base_ranker.py
@@ -15,50 +15,39 @@ PointwiseTrainBatch = Tuple[InputBatch, torch.FloatTensor]
 PairwiseTrainBatch = Tuple[InputBatch, InputBatch]
 ValTestBatch = Tuple[torch.LongTensor, torch.LongTensor, InputBatch, torch.LongTensor]
 
-
-class BaseRanker(LightningModule, abc.ABC):
+class DatalessBaseRanker(LightningModule, abc.ABC):
     """Abstract base class for re-rankers. Implements average precision and reciprocal rank validation.
     This class needs to be extended and (at least) the following methods must be implemented:
         * forward
-        * configure_optimizers
+        * configure_optimizers (if not supplied in the DataModule)
 
     Args:
         hparams (Dict[str, Any]): All model hyperparameters
-        train_ds (Union[PointwiseTrainDatasetBase, PairwiseTrainDatasetBase]): The training dataset
-        val_ds (Optional[ValTestDatasetBase]): The validation dataset
-        test_ds (Optional[ValTestDatasetBase]): The testing dataset
+        training_mode (str): 'pointwise' or 'pairwise'
         loss_margin (float, optional): Margin used in pairwise loss
-        batch_size (int): The batch size
-        num_workers (int, optional): Number of DataLoader workers. Defaults to 16.
     """
-    def __init__(self, hparams: Dict[str, Any],
-                 train_ds: Union[PointwiseTrainDatasetBase, PairwiseTrainDatasetBase],
-                 val_ds: Optional[ValTestDatasetBase], test_ds: Optional[ValTestDatasetBase],
-                 loss_margin: Optional[float],
-                 batch_size: int,
-                 num_workers: int = 16):
+    def __init__(self,
+                 training_mode: Optional[str] = None,
+                 loss_margin: Optional[float] = None):
         super().__init__()
-        self.save_hyperparameters(hparams)
 
-        self.train_ds = train_ds
-        self.val_ds = val_ds
-        self.test_ds = test_ds
-        self.loss_margin = loss_margin
-        self.batch_size = batch_size
-        self.num_workers = num_workers
-        if issubclass(train_ds.__class__, PointwiseTrainDatasetBase):
-            self.training_mode = 'pointwise'
+        self.save_hyperparameters()
+
+        self.training_mode = training_mode
+
+        if self.training_mode == 'pointwise':
             self.bce = torch.nn.BCEWithLogitsLoss()
-        elif issubclass(train_ds.__class__, PairwiseTrainDatasetBase):
-            self.training_mode = 'pairwise'
+        elif self.training_mode == 'pairwise':
+            self.loss_margin = loss_margin
         else:
-            self.training_mode = None
-
+            raise ValueError(f'Unknow training mode: {training_mode}'))
+        
         self.val_metrics = MetricCollection([
             RetrievalMAP(compute_on_step=False),
             RetrievalMRR(compute_on_step=False),
             RetrievalNormalizedDCG(compute_on_step=False)
         ], prefix='val_')
+        
 
     @property
     def val_metric_names(self) -> Sequence[str]:
@@ -69,15 +58,6 @@ class BaseRanker(LightningModule, abc.ABC):
         """
         return self.val_metrics.keys()
 
-    def train_dataloader(self) -> DataLoader:
-        """Return a trainset DataLoader. If the trainset object has a function named `collate_fn`,
-        it is used.
-
-        Returns:
-            DataLoader: The DataLoader
-        """
-        return DataLoader(self.train_ds, batch_size=self.batch_size, shuffle=True,
-                          num_workers=self.num_workers, collate_fn=getattr(self.train_ds, 'collate_fn', None))
 
     def training_step(self, batch: Union[PointwiseTrainBatch, PairwiseTrainBatch], batch_idx: int) -> torch.Tensor:
         """Train a single batch.
@@ -102,17 +82,6 @@ class BaseRanker(LightningModule, abc.ABC):
         self.log('train_loss', loss)
         return loss
 
-    def val_dataloader(self) -> Optional[DataLoader]:
-        """Return a validationset DataLoader if the validationset exists. If the validationset object has a function
-        named `collate_fn`, it is used.
-
-        Returns:
-            Optional[DataLoader]: The DataLoader, or None if there is no validation dataset
-        """
-        if self.val_ds is None:
-            return None
-        return DataLoader(self.val_ds, batch_size=self.batch_size, shuffle=False,
-                          num_workers=self.num_workers, collate_fn=getattr(self.val_ds, 'collate_fn', None))
 
     def validation_step(self, batch: ValTestBatch, batch_idx: int) -> Dict[str, torch.Tensor]:
         """Process a single validation batch. The returned query IDs are internal integer IDs.
@@ -127,6 +96,7 @@ class BaseRanker(LightningModule, abc.ABC):
         q_ids, _, inputs, labels = batch
         return {'q_ids': q_ids, 'predictions': self(inputs).flatten(), 'labels': labels}
 
+
     def validation_step_end(self, step_results: Dict[str, torch.Tensor]):
         """Update the validation metrics.
 
@@ -134,6 +104,7 @@ class BaseRanker(LightningModule, abc.ABC):
             step_results (Dict[str, torch.Tensor]): Results from a single validation step
         """
         self.val_metrics(step_results['predictions'], step_results['labels'], indexes=step_results['q_ids'])
+
 
     def validation_epoch_end(self, val_results: Iterable[Dict[str, torch.Tensor]]):
         """Compute validation metrics. The results may be approximate.
@@ -145,19 +116,8 @@ class BaseRanker(LightningModule, abc.ABC):
             self.log(metric, value, sync_dist=True)
         self.val_metrics.reset()
 
-    def predict_dataloader(self) -> Optional[DataLoader]:
-        """Return a testset DataLoader if the testset exists. If the testset object has a function
-        named `collate_fn`, it is used.
 
-        Returns:
-            Optional[DataLoader]: The DataLoader, or None if there is no testing dataset
-        """
-        if self.test_ds is None:
-            return None
-        return DataLoader(self.test_ds, batch_size=self.batch_size, shuffle=False,
-                          num_workers=self.num_workers, collate_fn=getattr(self.test_ds, 'collate_fn', None))
-
-    def predict_step(self, batch: ValTestBatch, batch_idx: int, dataloader_idx: int) -> Dict[str, torch.Tensor]:
+     def predict_step(self, batch: ValTestBatch, batch_idx: int, dataloader_idx: int = 0) -> Dict[str, torch.Tensor]:
         """Predict a single batch. The returned query and document IDs are internal integer IDs.
 
         Args:
@@ -174,3 +134,79 @@ class BaseRanker(LightningModule, abc.ABC):
             'doc_ids': doc_ids,
             'predictions': self(inputs).flatten()
         }
+
+
+class BaseRanker(DatalessBaseRanker, abc.ABC):
+    """Abstract base class for re-rankers. Implements average precision and reciprocal rank validation.
+    This class needs to be extended and (at least) the following methods must be implemented:
+        * forward
+        * configure_optimizers
+
+    Args:
+        hparams (Dict[str, Any]): All model hyperparameters
+        train_ds (Union[PointwiseTrainDatasetBase, PairwiseTrainDatasetBase]): The training dataset
+        val_ds (Optional[ValTestDatasetBase]): The validation dataset
+        test_ds (Optional[ValTestDatasetBase]): The testing dataset
+        loss_margin (float, optional): Margin used in pairwise loss
+        batch_size (int): The batch size
+        num_workers (int, optional): Number of DataLoader workers. Defaults to 16.
+    """
+    def __init__(self, hparams: Dict[str, Any],
+                 train_ds: Union[PointwiseTrainDatasetBase, PairwiseTrainDatasetBase],
+                 val_ds: Optional[ValTestDatasetBase],
+                 test_ds: Optional[ValTestDatasetBase],
+                 loss_margin: Optional[float],
+                 batch_size: int,
+                 num_workers: int = 16):
+        if issubclass(train_ds.__class__, PointwiseTrainDatasetBase):
+            training_mode = 'pointwise'
+        elif issubclass(train_ds.__class__, PairwiseTrainDatasetBase):
+            training_mode = 'pairwise'
+
+        super().__init__(training_mode=training_mode,
+                         loss_margin=loss_margin)
+
+        self.train_ds = train_ds
+        self.val_ds = val_ds
+        self.test_ds = test_ds
+
+
+    def _build_dataloader(self, dataset: Dataset, shuffle: bool) -> DataLoader:
+        return DataLoader(dataset,
+                          shuffle=shuffle,
+                          batch_size=self.batch_size,
+                          num_workers=self.num_workers,
+                          collate_fn=getattr(self.train_ds, 'collate_fn', None))
+
+    def train_dataloader(self) -> DataLoader:
+        """Return a trainset DataLoader. If the trainset object has a function named `collate_fn`,
+        it is used.
+
+        Returns:
+            DataLoader: The DataLoader
+        """
+        return self._build_dataloader(self.train_ds, True)
+
+
+    def val_dataloader(self) -> Optional[DataLoader]:
+        """Return a validationset DataLoader if the validationset exists. If the validationset object has a function
+        named `collate_fn`, it is used.
+
+        Returns:
+            Optional[DataLoader]: The DataLoader, or None if there is no validation dataset
+        """
+        if self.val_ds is None:
+            return None
+        return self._build_dataloader(self.val_ds, False)
+
+
+    def predict_dataloader(self) -> Optional[DataLoader]:
+        """Return a testset DataLoader if the testset exists. If the testset object has a function
+        named `collate_fn`, it is used.
+
+        Returns:
+            Optional[DataLoader]: The DataLoader, or None if there is no testing dataset
+        """
+        if self.test_ds is None:
+            return None
+        return self._build_dataloader(self.test_ds, False)

--- a/src/ranking_utils/lightning/base_ranker.py
+++ b/src/ranking_utils/lightning/base_ranker.py
@@ -27,12 +27,14 @@ class DatalessBaseRanker(LightningModule, abc.ABC):
         loss_margin (float, optional): Margin used in pairwise loss
     """
     def __init__(self,
+                 hparams: Optional[Dict[str, Any]] = None,
                  training_mode: Optional[str] = None,
                  loss_margin: Optional[float] = None):
         super().__init__()
 
-        self.save_hyperparameters()
-
+        if(hparams is not None):
+            self.save_hyperparameters(hparams)
+            
         self.training_mode = training_mode
 
         if self.training_mode == 'pointwise':
@@ -163,16 +165,10 @@ class BaseRanker(DatalessBaseRanker, abc.ABC):
         elif issubclass(train_ds.__class__, PairwiseTrainDatasetBase):
             training_mode = 'pairwise'
 
-        super().__init__(training_mode=training_mode,
+        super().__init__(hparams=hparams,
+                         training_mode=training_mode,
                          loss_margin=loss_margin)
 
-        # FIXME: I think what's supposed to happen here is to fold hparams into the previously
-        # extracted (by save_hyperparameters, in DataLessBaseRanker.__init__) hparams.
-        # This means, though, that values in hparams will override those extracted from
-        # the call stack. Is that what we want?
-        #
-        # FK 2022-01-26
-        self.hparams.update(hparams)
         # For compatibility with existing code. These also show up in hparams but may be
         # different from self.hparams['batch_size'] etc. See previous comment.
         self.batch_size = batch_size


### PR DESCRIPTION
This PR introduces a DatalessRanker base class for rankers that don't hold their training/val/test datasets. This is meant to enable code that holds this data in the new LightningDataModules.

Its code is extracted from BaseRanker, whose functionality is now essentially split between the two classes. BaseRanker's behavior is unchanged except that it inherits this new base class.