### PR TITLE
Add contrastive training mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,14 @@ data_module = H5DataModule(
 )
 model = MyRanker(...)
 data_module.training_mode = model.training_mode = TrainingMode.PAIRWISE
-model.pairwise_loss_margin = 0.2
+model.margin = 0.2
 Trainer(...).fit(model=model, datamodule=data_module)
 ```
+
+The following training modes are supported:
+* `TrainingMode.POINTWISE`
+* `TrainingMode.PAIRWISE`
+* `TrainingMode.CONTRASTIVE`
 
 #### Validation
 After each epoch, the ranker automatically computes the following ranking metrics on the validation set:

--- a/ranking_utils/datasets/__init__.py
+++ b/ranking_utils/datasets/__init__.py
@@ -1,5 +1,6 @@
 import abc
 import csv
+import logging
 import random
 from collections import defaultdict
 from pathlib import Path
@@ -8,6 +9,8 @@ from typing import Any, Dict, Iterable, List, Set, Tuple, Union
 import h5py
 import numpy as np
 from tqdm import tqdm
+
+LOGGER = logging.getLogger(__name__)
 
 
 class TrainingSet(abc.ABC):
@@ -326,10 +329,14 @@ class ContrastiveTrainingSet(TrainingSet):
         result = []
         for q_id in self.train_ids:
             positives = self._get_all_positives(q_id)
+            negative_candidates = self._get_all_negatives(q_id)
+            if len(negative_candidates) < self.num_negatives:
+                LOGGER.warning(
+                    f"not enough negatives ({len(negative_candidates)}) for query {q_id}, skipping"
+                )
+                continue
             for positive in positives:
-                negative_candidates = self._get_all_negatives(q_id)
                 for _ in range(self._get_num_instances_per_positive(q_id)):
-                    assert len(negative_candidates) >= self.num_negatives
                     result.append(
                         (
                             q_id,

--- a/ranking_utils/datasets/__init__.py
+++ b/ranking_utils/datasets/__init__.py
@@ -358,6 +358,7 @@ class ContrastiveTrainingSet(TrainingSet):
                 ds["pos_doc_ids"][i] = pos_doc_id
                 for j, neg_doc_id in enumerate(neg_doc_ids):
                     ds["neg_doc_ids"][i * self.num_negatives + j] = neg_doc_id
+            ds["neg_doc_ids"].attrs["num_negatives"] = self.num_negatives
 
 
 class ValTestSet(object):

--- a/ranking_utils/datasets/__init__.py
+++ b/ranking_utils/datasets/__init__.py
@@ -3,25 +3,21 @@ import csv
 import random
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, Iterable, List, Set, Tuple, Union
+from typing import Any, Dict, Iterable, List, Set, Tuple, Union
 
 import h5py
 import numpy as np
 from tqdm import tqdm
 
 
-class TrainingSet(object):
-    """A training set iterator for pointwise or pairwise training instances."""
+class TrainingSet(abc.ABC):
+    """Base class for training set iterators."""
 
     def __init__(
         self,
         train_ids: Set[int],
         qrels: Dict[int, Dict[int, int]],
         pools: Dict[int, Set[int]],
-        num_negatives: int,
-        balance_labels: bool,
-        balance_queries: bool,
-        pairwise: bool = False,
     ) -> None:
         """Constructor.
 
@@ -29,28 +25,32 @@ class TrainingSet(object):
             train_ids (Set[int]): Training set query IDs.
             qrels (Dict[int, Dict[int, int]]): Query IDs mapped to document IDs mapped to relevance.
             pools (Dict[int, Set[int]]): Query IDs mapped to top retrieved documents.
-            num_negatives (int): Number of negative documents to sample for each positive.
-            balance_labels (bool): Whether to balance the total number of positives and negatives (pointwise training).
-            balance_queries (bool): Whether to balance the total number of instances for each query based on its number of positives.
-            pairwise (bool, optional): Yield pairwise training data. Defaults to False.
         """
         self.train_ids = train_ids
         self.qrels = qrels
         self.pools = pools
-        self.num_negatives = num_negatives
-        self.balance_labels = balance_labels
-        self.balance_queries = balance_queries
-        self.pairwise = pairwise
+        self.items = self._create_training_data()
 
-        if balance_queries:
-            self.percentiles = self._compute_percentiles()
-        if pairwise:
-            self.items = self._create_pairwise_data()
-        else:
-            self.items = self._create_pointwise_data()
+    @abc.abstractmethod
+    def _create_training_data(self) -> List[Any]:
+        """Create the training data as a list containint some structure of query and document IDs.
+
+        Returns:
+            List[Any]: The training data.
+        """
+        pass
+
+    @abc.abstractmethod
+    def save(self, dest: Path) -> None:
+        """Save the training set.
+
+        Args:
+            dest (Path): File to create.
+        """
+        pass
 
     def _get_docs_by_relevance(self, q_id: int) -> Dict[int, Set[int]]:
-        """Return all documents for a query from its pool and qrels, grouped by relevance.
+        """Return all documents for a query from its pool and QRels, grouped by relevance.
         Documents from the pool that have no associated relevance get a relevance of 0.
 
         Args:
@@ -103,7 +103,7 @@ class TrainingSet(object):
             float: The balancing factor.
         """
         num_positives = len(self._get_all_positives(q_id))
-        q25, q50, q75 = self.percentiles
+        q25, q50, q75 = self._compute_percentiles(self)
         if num_positives < q25:
             return 5.0
         elif num_positives < q50:
@@ -112,53 +112,51 @@ class TrainingSet(object):
             return 1.5
         return 1.0
 
-    def _get_triples(self, q_id: int) -> List[Tuple[int, int, int]]:
-        """Return all training triples for a query as tuples of query ID, positive document ID, negative document ID.
-        Adapted from https://github.com/ucasir/NPRF/blob/6387db2fce30ee2b9f659ad1addfe949e6349f85/utils/pair_generator.py#L100.
+    def __len__(self) -> int:
+        """Dataset length.
+
+        Returns:
+            int: The number of training instances.
+        """
+        return len(self.items)
+
+    def __iter__(self) -> Iterable[Any]:
+        """Yield all training examples.
+
+        Yields:
+            Tuple[Any]: The training examples.
+        """
+        yield from self.items
+
+
+class PointwiseTrainingSet(TrainingSet):
+    """A training set iterator for pointwise training instances."""
+
+    def __init__(
+        self,
+        train_ids: Set[int],
+        qrels: Dict[int, Dict[int, int]],
+        pools: Dict[int, Set[int]],
+        num_negatives: int,
+        balance_labels: bool,
+        balance_queries: bool,
+    ) -> None:
+        """Constructor.
 
         Args:
-            q_id (int): The query ID.
-
-        Returns:
-            List[Tuple[int, int, int]]: A list of training triples.
+            train_ids (Set[int]): Training set query IDs.
+            qrels (Dict[int, Dict[int, int]]): Query IDs mapped to document IDs mapped to relevance.
+            pools (Dict[int, Set[int]]): Query IDs mapped to top retrieved documents.
+            num_negatives (int): Number of negative documents to sample for each positive.
+            balance_labels (bool): Whether to balance the total number of positives and negatives.
+            balance_queries (bool): Whether to balance the total number of instances for each query based on its number of positives.
         """
-        docs = self._get_docs_by_relevance(q_id)
-        result = []
+        self.num_negatives = num_negatives
+        self.balance_labels = balance_labels
+        self.balance_queries = balance_queries
+        super().__init__(train_ids, qrels, pools)
 
-        if self.balance_queries:
-            # balance the number of instances for this query based on the number of positives
-            factor = self._get_balancing_factor(q_id)
-            num_negatives = int(self.num_negatives * factor)
-        else:
-            num_negatives = self.num_negatives
-
-        # available relevances sorted in ascending order
-        rels = sorted(docs.keys())
-
-        # start at 1, as the lowest relevance can not be used as positives
-        for i, rel in enumerate(rels[1:], start=1):
-            # take all documents with lower relevance as negative candidates
-            negative_candidates = set.union(*[docs[rels[j]] for j in range(i)])
-            for positive in docs[rel]:
-                sample_size = min(num_negatives, len(negative_candidates))
-                negatives = random.sample(negative_candidates, sample_size)
-                result.extend(
-                    zip([q_id] * sample_size, [positive] * sample_size, negatives)
-                )
-        return result
-
-    def _create_pairwise_data(self) -> List[Tuple[int, int, int]]:
-        """Create pairwise training data as tuples of query ID, positive document ID, negative document ID.
-
-        Returns:
-            List[Tuple[int, int, int]]: The training data.
-        """
-        result = []
-        for q_id in self.train_ids:
-            result.extend(self._get_triples(q_id))
-        return result
-
-    def _create_pointwise_data(self) -> List[Tuple[int, int, int]]:
+    def _create_training_data(self) -> List[Tuple[int, int, int]]:
         """Create pointwise training data as tuples of query ID, document ID, label.
 
         Returns:
@@ -195,23 +193,100 @@ class TrainingSet(object):
                     result.append((q_id, doc_id, 0))
         return result
 
-    def __len__(self) -> int:
-        """Dataset length.
+    def save(self, dest: Path) -> None:
+        """Save the training set.
+
+        Args:
+            dest (Path): File to create.
+        """
+        num_items = len(self)
+        with h5py.File(dest, "w") as fp:
+            ds = {
+                "q_ids": fp.create_dataset("q_ids", (num_items,), dtype="int32"),
+                "doc_ids": fp.create_dataset("doc_ids", (num_items,), dtype="int32"),
+                "labels": fp.create_dataset("labels", (num_items,), dtype="int32"),
+            }
+            for i, (q_id, doc_id, label) in enumerate(
+                tqdm(self, desc="Saving pointwise training set")
+            ):
+                ds["q_ids"][i] = q_id
+                ds["doc_ids"][i] = doc_id
+                ds["labels"][i] = label
+
+
+class PairwiseTrainingSet(TrainingSet):
+    """A training set iterator for pairwise training instances."""
+
+    def __init__(
+        self,
+        train_ids: Set[int],
+        qrels: Dict[int, Dict[int, int]],
+        pools: Dict[int, Set[int]],
+        num_negatives: int,
+        balance_queries: bool,
+    ) -> None:
+        """Constructor.
+
+        Args:
+            train_ids (Set[int]): Training set query IDs.
+            qrels (Dict[int, Dict[int, int]]): Query IDs mapped to document IDs mapped to relevance.
+            pools (Dict[int, Set[int]]): Query IDs mapped to top retrieved documents.
+            num_negatives (int): Number of negative documents to sample for each positive.
+            balance_queries (bool): Whether to balance the total number of instances for each query based on its number of positives.
+            pairwise (bool, optional): Yield pairwise training data. Defaults to False.
+        """
+        self.train_ids = train_ids
+        self.qrels = qrels
+        self.pools = pools
+        self.num_negatives = num_negatives
+        self.balance_queries = balance_queries
+        super().__init__(train_ids, qrels, pools)
+
+    def _get_triples(self, q_id: int) -> List[Tuple[int, int, int]]:
+        """Return all training triples for a query as tuples of query ID, positive document ID, negative document ID.
+        Adapted from https://github.com/ucasir/NPRF/blob/6387db2fce30ee2b9f659ad1addfe949e6349f85/utils/pair_generator.py#L100.
+
+        Args:
+            q_id (int): The query ID.
 
         Returns:
-            int: The number of training instances.
+            List[Tuple[int, int, int]]: A list of training triples.
         """
-        return len(self.items)
+        docs = self._get_docs_by_relevance(q_id)
+        result = []
 
-    def __iter__(self) -> Iterable[Tuple[int, int, int]]:
-        """Yield all training examples.
+        if self.balance_queries:
+            # balance the number of instances for this query based on the number of positives
+            factor = self._get_balancing_factor(q_id)
+            num_negatives = int(self.num_negatives * factor)
+        else:
+            num_negatives = self.num_negatives
 
-        Yields:
-            Tuple[int, int, int]: Yields one of
-                * query ID, document ID, label (pointwise training),
-                * query ID, positive document ID, negative document ID (pairwise training).
+        # available relevances sorted in ascending order
+        rels = sorted(docs.keys())
+
+        # start at 1, as the lowest relevance can not be used as positives
+        for i, rel in enumerate(rels[1:], start=1):
+            # take all documents with lower relevance as negative candidates
+            negative_candidates = set.union(*[docs[rels[j]] for j in range(i)])
+            for positive in docs[rel]:
+                sample_size = min(num_negatives, len(negative_candidates))
+                negatives = random.sample(negative_candidates, sample_size)
+                result.extend(
+                    zip([q_id] * sample_size, [positive] * sample_size, negatives)
+                )
+        return result
+
+    def _create_training_data(self) -> List[Tuple[int, int, int]]:
+        """Create pairwise training data as tuples of query ID, positive document ID, negative document ID.
+
+        Returns:
+            List[Tuple[int, int, int]]: The training data.
         """
-        yield from self.items
+        result = []
+        for q_id in self.train_ids:
+            result.extend(self._get_triples(q_id))
+        return result
 
     def save(self, dest: Path) -> None:
         """Save the training set.
@@ -220,39 +295,22 @@ class TrainingSet(object):
             dest (Path): File to create.
         """
         num_items = len(self)
-
-        if self.pairwise:
-            with h5py.File(dest, "w") as fp:
-                ds = {
-                    "q_ids": fp.create_dataset("q_ids", (num_items,), dtype="int32"),
-                    "pos_doc_ids": fp.create_dataset(
-                        "pos_doc_ids", (num_items,), dtype="int32"
-                    ),
-                    "neg_doc_ids": fp.create_dataset(
-                        "neg_doc_ids", (num_items,), dtype="int32"
-                    ),
-                }
-                for i, (q_id, pos_doc_id, neg_doc_id) in enumerate(
-                    tqdm(self, desc="Saving pairwise training set")
-                ):
-                    ds["q_ids"][i] = q_id
-                    ds["pos_doc_ids"][i] = pos_doc_id
-                    ds["neg_doc_ids"][i] = neg_doc_id
-        else:
-            with h5py.File(dest, "w") as fp:
-                ds = {
-                    "q_ids": fp.create_dataset("q_ids", (num_items,), dtype="int32"),
-                    "doc_ids": fp.create_dataset(
-                        "doc_ids", (num_items,), dtype="int32"
-                    ),
-                    "labels": fp.create_dataset("labels", (num_items,), dtype="int32"),
-                }
-                for i, (q_id, doc_id, label) in enumerate(
-                    tqdm(self, desc="Saving pointwise training set")
-                ):
-                    ds["q_ids"][i] = q_id
-                    ds["doc_ids"][i] = doc_id
-                    ds["labels"][i] = label
+        with h5py.File(dest, "w") as fp:
+            ds = {
+                "q_ids": fp.create_dataset("q_ids", (num_items,), dtype="int32"),
+                "pos_doc_ids": fp.create_dataset(
+                    "pos_doc_ids", (num_items,), dtype="int32"
+                ),
+                "neg_doc_ids": fp.create_dataset(
+                    "neg_doc_ids", (num_items,), dtype="int32"
+                ),
+            }
+            for i, (q_id, pos_doc_id, neg_doc_id) in enumerate(
+                tqdm(self, desc="Saving pairwise training set")
+            ):
+                ds["q_ids"][i] = q_id
+                ds["pos_doc_ids"][i] = pos_doc_id
+                ds["neg_doc_ids"][i] = neg_doc_id
 
 
 class ValTestSet(object):
@@ -404,35 +462,56 @@ class Dataset(object):
 
         self.folds.append((train_ids, val_ids, test_ids))
 
-    def get_training_set(
+    def get_pointwise_training_set(
         self,
         fold: int,
         num_negatives: int,
         balance_labels: bool,
         balance_queries: bool,
-        pairwise: bool = False,
-    ) -> TrainingSet:
-        """Training set iterator for a given fold.
+    ) -> PointwiseTrainingSet:
+        """Pointwise training set iterator for a given fold.
 
         Args:
             fold (int): Fold ID.
             num_negatives (int): Number of negative documents to sample for each positive.
-            balance_labels (bool): Whether to balance the total number of positives and negatives (pointwise training).
+            balance_labels (bool): Whether to balance the total number of positives and negatives.
             balance_queries (bool): Whether to balance the total number of instances for each query based on its number of positives.
-            pairwise (bool, optional): Yield pairwise training data. Defaults to False.
 
         Returns:
-            TrainingSet: The training set.
+            PointwiseTrainingSet: The training set.
         """
-        train_ids = self.folds[fold][0]
-        return TrainingSet(
-            train_ids,
+        return PointwiseTrainingSet(
+            self.folds[fold][0],
             self.qrels,
             self.pools,
             num_negatives,
             balance_labels,
             balance_queries,
-            pairwise,
+        )
+
+    def get_pairwise_training_set(
+        self,
+        fold: int,
+        num_negatives: int,
+        balance_queries: bool,
+    ) -> PairwiseTrainingSet:
+        """Pairwise training set iterator for a given fold.
+
+        Args:
+            fold (int): Fold ID.
+            num_negatives (int): Number of negative documents to sample for each positive.
+            balance_labels (bool): Whether to balance the total number of positives and negatives.
+            balance_queries (bool): Whether to balance the total number of instances for each query based on its number of positives.
+
+        Returns:
+            PairwiseTrainingSet: The training set.
+        """
+        return PairwiseTrainingSet(
+            self.folds[fold][0],
+            self.qrels,
+            self.pools,
+            num_negatives,
+            balance_queries,
         )
 
     def get_val_set(self, fold: int) -> ValTestSet:
@@ -519,17 +598,19 @@ class Dataset(object):
             balance_queries (bool): Whether to balance the total number of instances for each query based on its number of positives.
         """
         target_dir.mkdir(parents=True, exist_ok=True)
-        self.save_collection(target_dir / "data.h5")
-        self.save_qrels(target_dir / "qrels.tsv")
+        # self.save_collection(target_dir / "data.h5")
+        # self.save_qrels(target_dir / "qrels.tsv")
         for fold in range(len(self.folds)):
             fold_dir = target_dir / f"fold_{fold}"
             fold_dir.mkdir(parents=True, exist_ok=True)
-            self.get_training_set(
-                fold, num_negatives, balance_labels, balance_queries, pairwise=False
+            self.get_pointwise_training_set(
+                fold, num_negatives, balance_labels, balance_queries
             ).save(fold_dir / "train_pointwise.h5")
-            self.get_training_set(
-                fold, num_negatives, balance_labels, balance_queries, pairwise=True
-            ).save(fold_dir / "train_pairwise.h5")
+
+            self.get_pairwise_training_set(fold, num_negatives, balance_queries).save(
+                fold_dir / "train_pairwise.h5"
+            )
+
             self.get_val_set(fold).save(fold_dir / "val.h5")
             self.get_test_set(fold).save(fold_dir / "test.h5")
 

--- a/ranking_utils/model/__init__.py
+++ b/ranking_utils/model/__init__.py
@@ -116,7 +116,7 @@ class Ranker(LightningModule):
             # split into individual negatives for each instance
             neg_outputs = neg_outputs.reshape((pos_outputs.shape[0], -1, 1)).sum(1)
 
-            contrastive_loss = pos_outputs / (pos_outputs + neg_outputs)
+            contrastive_loss = -torch.log(pos_outputs / (pos_outputs + neg_outputs))
             loss = torch.mean(contrastive_loss.flatten())
 
         self.log("train_loss", loss)

--- a/ranking_utils/model/__init__.py
+++ b/ranking_utils/model/__init__.py
@@ -59,16 +59,19 @@ class Ranker(LightningModule):
         self,
         training_mode: TrainingMode = TrainingMode.POINTWISE,
         pairwise_loss_margin: float = 1.0,
+        in_batch_negatives: bool = True,
     ) -> None:
         """Constructor.
 
         Args:
             training_mode (TrainingMode, optional): How to train the model. Defaults to TrainingMode.POINTWISE.
             pairwise_loss_margin (float, optional): Margin used in pairwise loss. Defaults to 1.0.
+            in_batch_negatives (bool, optional): Whether to enable in-batch negatives for contrastive training. Defaults to True.
         """
         super().__init__()
         self.training_mode = training_mode
         self.pairwise_loss_margin = pairwise_loss_margin
+        self.in_batch_negatives = in_batch_negatives
         self.bce = torch.nn.BCEWithLogitsLoss()
 
         metrics = [RetrievalMAP, RetrievalMRR, RetrievalNormalizedDCG]
@@ -113,10 +116,20 @@ class Ranker(LightningModule):
             pos_outputs = torch.exp(torch.sigmoid(self(pos_model_batch)))
             neg_outputs = torch.exp(torch.sigmoid(self(neg_model_batch)))
 
-            # split into individual negatives for each instance
-            neg_outputs = neg_outputs.reshape((pos_outputs.shape[0], -1, 1)).sum(1)
+            if self.in_batch_negatives:
+                # divide each positive score by all scores
+                all_scores = pos_outputs.sum(0) + neg_outputs.sum(0)
+                contrastive_loss = -torch.log(
+                    pos_outputs / all_scores.repeat(pos_outputs.shape[0])
+                )
+            else:
+                # split into individual negatives for each instance
+                # divide each positive score by itself and the corresponding negatives
+                neg_outputs_split = neg_outputs.reshape((pos_outputs.shape[0], -1, 1))
+                contrastive_loss = -torch.log(
+                    pos_outputs / (pos_outputs + neg_outputs_split.sum(1))
+                )
 
-            contrastive_loss = -torch.log(pos_outputs / (pos_outputs + neg_outputs))
             loss = torch.mean(contrastive_loss.flatten())
 
         self.log("train_loss", loss)

--- a/ranking_utils/model/data/__init__.py
+++ b/ranking_utils/model/data/__init__.py
@@ -1,8 +1,12 @@
 import abc
+import itertools
 from typing import Iterable, Iterator, Tuple, Union
 
 import torch
 from ranking_utils.model import (
+    ContrastiveTrainingBatch,
+    ContrastiveTrainingInput,
+    ContrastiveTrainingInstance,
     ModelBatch,
     ModelInput,
     PairwiseTrainingBatch,
@@ -14,12 +18,21 @@ from ranking_utils.model import (
     PredictionBatch,
     PredictionInput,
     PredictionInstance,
+    TrainingBatch,
+    TrainingInput,
+    TrainingInstance,
     TrainingMode,
     ValTestBatch,
     ValTestInput,
     ValTestInstance,
 )
 from torch.utils.data import Dataset
+
+TrainingInputs = Union[
+    Iterable[PointwiseTrainingInput],
+    Iterable[PairwiseTrainingInput],
+    Iterable[PointwiseTrainingInput],
+]
 
 
 class DataProcessor(abc.ABC):
@@ -85,6 +98,15 @@ class TrainingDataset(Dataset, abc.ABC):
         pass
 
     @abc.abstractmethod
+    def _num_contrastive_instances(self) -> int:
+        """Return the number of contrastive training instances.
+
+        Returns:
+            int: The number of contrastive training instances.
+        """
+        pass
+
+    @abc.abstractmethod
     def _get_pointwise_instance(self, index: int) -> PointwiseTrainingInstance:
         """Return the pointwise training instance corresponding to an index.
 
@@ -108,16 +130,26 @@ class TrainingDataset(Dataset, abc.ABC):
         """
         pass
 
-    def __getitem__(
-        self, index: int
-    ) -> Union[PointwiseTrainingInput, PairwiseTrainingInput]:
+    @abc.abstractmethod
+    def _get_contrastive_instance(self, index: int) -> ContrastiveTrainingInstance:
+        """Return the contrastive training instance corresponding to an index.
+
+        Args:
+            index (int): The index.
+
+        Returns:
+            ContrastiveTrainingInstance: The corresponding training instance.
+        """
+        pass
+
+    def __getitem__(self, index: int) -> TrainingInput:
         """Return a training input.
 
         Args:
             index (int): Item index.
 
         Returns:
-            Union[PointwiseTrainingInput, PairwiseTrainingInput]: Input, depending on the mode.
+            TrainingInput: Input, depending on the mode.
         """
         if self.mode == TrainingMode.POINTWISE:
             query, doc, label = self._get_pointwise_instance(index)
@@ -128,6 +160,17 @@ class TrainingDataset(Dataset, abc.ABC):
             return (
                 self.data_processor.get_model_input(query, pos_doc),
                 self.data_processor.get_model_input(query, neg_doc),
+                index,
+            )
+
+        if self.mode == TrainingMode.CONTRASTIVE:
+            query, pos_doc, neg_docs = self._get_contrastive_instance(index)
+            return (
+                self.data_processor.get_model_input(query, pos_doc),
+                [
+                    self.data_processor.get_model_input(query, neg_doc)
+                    for neg_doc in neg_docs
+                ],
                 index,
             )
 
@@ -143,19 +186,17 @@ class TrainingDataset(Dataset, abc.ABC):
         if self.mode == TrainingMode.PAIRWISE:
             return self._num_pairwise_instances()
 
-    def collate_fn(
-        self,
-        inputs: Union[
-            Iterable[PointwiseTrainingInput], Iterable[PairwiseTrainingInput]
-        ],
-    ) -> Union[PointwiseTrainingBatch, PairwiseTrainingBatch]:
+        if self.mode == TrainingMode.CONTRASTIVE:
+            return self._num_contrastive_instances()
+
+    def collate_fn(self, inputs: TrainingInputs) -> TrainingBatch:
         """Collate inputs into a batch.
 
         Args:
-            inputs (Union[Iterable[PointwiseTrainingInput], Iterable[PairwiseTrainingInput]]): The inputs.
+            inputs (TrainingInputs): The inputs.
 
         Returns:
-            Union[PointwiseTrainingBatch, PairwiseTrainingBatch]: The resulting batch.
+            TrainingBatch: The resulting batch.
         """
         if self.mode == TrainingMode.POINTWISE:
             model_inputs, labels, indices = zip(*inputs)
@@ -170,6 +211,14 @@ class TrainingDataset(Dataset, abc.ABC):
             return (
                 self.data_processor.get_model_batch(pos_inputs),
                 self.data_processor.get_model_batch(neg_inputs),
+                torch.LongTensor(indices),
+            )
+
+        if self.mode == TrainingMode.CONTRASTIVE:
+            pos_inputs, neg_input_lists, indices = zip(*inputs)
+            return (
+                self.data_processor.get_model_batch(pos_inputs),
+                self.data_processor.get_model_batch(itertools.chain(*neg_input_lists)),
                 torch.LongTensor(indices),
             )
 

--- a/ranking_utils/model/data/__init__.py
+++ b/ranking_utils/model/data/__init__.py
@@ -4,15 +4,11 @@ from typing import Iterable, Iterator, Tuple, Union
 
 import torch
 from ranking_utils.model import (
-    ContrastiveTrainingBatch,
-    ContrastiveTrainingInput,
     ContrastiveTrainingInstance,
     ModelBatch,
     ModelInput,
-    PairwiseTrainingBatch,
     PairwiseTrainingInput,
     PairwiseTrainingInstance,
-    PointwiseTrainingBatch,
     PointwiseTrainingInput,
     PointwiseTrainingInstance,
     PredictionBatch,
@@ -20,7 +16,6 @@ from ranking_utils.model import (
     PredictionInstance,
     TrainingBatch,
     TrainingInput,
-    TrainingInstance,
     TrainingMode,
     ValTestBatch,
     ValTestInput,

--- a/ranking_utils/model/data/h5.py
+++ b/ranking_utils/model/data/h5.py
@@ -2,7 +2,6 @@ import logging
 import os
 import tempfile
 from pathlib import Path
-from re import I
 from typing import Iterator, Optional, Tuple, Union
 
 import h5py

--- a/ranking_utils/scripts/config/create_h5_data.yaml
+++ b/ranking_utils/scripts/config/create_h5_data.yaml
@@ -6,11 +6,11 @@ random_seed: 123
 
 training:
 
-  # number of negative documents to sample for each positive
-  num_negatives: 1
+  # Number of training instances for each relevant document.
+  num_instances_per_positive: 1
 
-  # whether to balance the total number of positives and negatives (pointwise training)
-  balance_labels: True
-
-  # whether to balance the total number of instances for each query based on its number of positives
+  # Whether to balance the total number of instances for each query based on its number of positives.
   balance_queries: False
+
+  # Whether to balance the total number of positives and negatives (pointwise).
+  balance_labels: True

--- a/ranking_utils/scripts/config/create_h5_data.yaml
+++ b/ranking_utils/scripts/config/create_h5_data.yaml
@@ -16,4 +16,4 @@ training:
   balance_labels: True
 
   # Number of negative documents to contrast each positive (contrastive).
-  num_negatives: 16
+  num_negatives: 8

--- a/ranking_utils/scripts/config/create_h5_data.yaml
+++ b/ranking_utils/scripts/config/create_h5_data.yaml
@@ -14,3 +14,6 @@ training:
 
   # Whether to balance the total number of positives and negatives (pointwise).
   balance_labels: True
+
+  # Number of negative documents to contrast each positive (contrastive).
+  num_negatives: 16

--- a/ranking_utils/scripts/create_h5_data.py
+++ b/ranking_utils/scripts/create_h5_data.py
@@ -12,13 +12,7 @@ from pytorch_lightning import seed_everything
 @hydra.main(config_path="config", config_name="create_h5_data")
 def main(config: DictConfig) -> None:
     seed_everything(config.random_seed)
-    instantiate(config.dataset).save(
-        Path.cwd(),
-        config.training.num_instances_per_positive,
-        config.training.balance_queries,
-        config.training.balance_labels,
-        config.training.num_negatives,
-    )
+    instantiate(config.dataset).save(Path.cwd(), **config.training)
 
 
 if __name__ == "__main__":

--- a/ranking_utils/scripts/create_h5_data.py
+++ b/ranking_utils/scripts/create_h5_data.py
@@ -17,6 +17,7 @@ def main(config: DictConfig) -> None:
         config.training.num_instances_per_positive,
         config.training.balance_queries,
         config.training.balance_labels,
+        config.training.num_negatives,
     )
 
 

--- a/ranking_utils/scripts/create_h5_data.py
+++ b/ranking_utils/scripts/create_h5_data.py
@@ -14,9 +14,9 @@ def main(config: DictConfig) -> None:
     seed_everything(config.random_seed)
     instantiate(config.dataset).save(
         Path.cwd(),
-        config.training.num_negatives,
-        config.training.balance_labels,
+        config.training.num_instances_per_positive,
         config.training.balance_queries,
+        config.training.balance_labels,
     )
 
 


### PR DESCRIPTION
This PR adds a new training mode using a contrastive loss function (`TrainingMode.CONTRASTIVE`).

* Create a base class for training sets and subclasses for pointwise, pairwise and contrastive training data.
* Add a contrastive loss function and training mode.
* Rename `pairwise_loss_margin` to `margin`.
* Sample negative documents from QRels as well (not just from the pools).