### PR TITLE
Add subsetting of the datasets

### DIFF
--- a/ranking_utils/model/data/__init__.py
+++ b/ranking_utils/model/data/__init__.py
@@ -3,6 +3,8 @@ import itertools
 from typing import Iterable, Iterator, Tuple, Union
 
 import torch
+from torch.utils.data import Dataset, Subset
+
 from ranking_utils.model import (
     ContrastiveTrainingInstance,
     ModelBatch,
@@ -21,13 +23,33 @@ from ranking_utils.model import (
     ValTestInput,
     ValTestInstance,
 )
-from torch.utils.data import Dataset
 
 TrainingInputs = Union[
     Iterable[PointwiseTrainingInput],
     Iterable[PairwiseTrainingInput],
     Iterable[PointwiseTrainingInput],
 ]
+
+
+def subset_dataset(dataset: Dataset, subset: Union[int, float, None]) -> Dataset:
+    """Subsets the dataset
+
+    Args:
+        dataset (Dataset): the dataset that should be subsetted
+        subset (Union[int, float, None]): specifies how the data is subset. Passing None will not performing any
+            subsetting. Passing an int will limit the dataset to its first `subset` entries and passing a float will
+            limit it to the first `|dataset|*subset` entries.
+
+    Returns:
+        Dataset: The subsetted dataset
+    """
+    if subset is None:
+        return dataset
+    elif isinstance(subset, int):
+        indices = range(subset)
+    elif isinstance(subset, float):
+        indices = range(int(len(dataset) * subset))
+    return Subset(dataset, indices)
 
 
 class DataProcessor(abc.ABC):

--- a/ranking_utils/model/data/h5.py
+++ b/ranking_utils/model/data/h5.py
@@ -260,8 +260,8 @@ class H5DataModule(LightningDataModule):
                 passed, it indicates that only the first `limit_train_set` entries in the training set should be used.
                 If a float is parsed, it indicates that only the first `|train_set|*limit_train_set` entries in the
                 training set should be used. E.g., limit_train_set=100 indicates to train on 100 dataset entries (or
-                less if the dataset does not have enough entries), whereas train_set=.5 indicates to train on 50% of the
-                dataset. Passing None will train on the entire dataset (this is the default).
+                less if the dataset does not have enough entries), whereas limit_train_set=.5 indicates to train on 50%
+                of the dataset. Passing None will train on the entire dataset (this is the default).
             limit_val_set (Union[int, float], optional): see limit_train_set for more information.
             limit_test_set (Union[int, float], optional): see limit_train_set for more information.
         """

--- a/ranking_utils/model/data/h5.py
+++ b/ranking_utils/model/data/h5.py
@@ -303,7 +303,7 @@ class H5DataModule(LightningDataModule):
         elif isinstance(subset, int):
             indices = range(subset)
         elif isinstance(subset, float):
-            indices = range(len(dataset)*subset)
+            indices = range(int(len(dataset)*subset))
         return Subset(dataset, indices)
 
     def train_dataloader(self) -> DataLoader:


### PR DESCRIPTION
Sometimes one may just want to train, evaluate or test on a smaller subset of the dataset (e.g., for testing or to see if the model is able to overfit on this smaller portion).

This feature is implement by adding three new parameters to the `H5DataModule`: `limit_train_set`, `limit_val_set`, and `limit_test_set`. They allow for no subsetting, using a fixed number of entries, or using a portion of the full dataset.
All three parameters are optional and the default behavior is unchanged (i.e, no subsetting).